### PR TITLE
Add SoGBazaar

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 <p></p></li>
 </ul></p>
 
-<h3 id="commingsoon">Comming soon</h3>
+<h3 id="comingsoon">Coming soon</h3>
 
 <ul>
 <li><a href="https://en.bitrefill.com/">Bitrefill</a>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,13 @@
 
 <p><li><strong>URI:</strong> 02669e1e43577c14a4ae796a38e0cfdadb548615058e367bd96bf825e62c0932ce@34.200.241.1:9735</li></ul>
 
+<li><p><a href="https://sogbazaar.com/">SoGBazaar</a></p>
+
+<ul>
+<li>Posters and digital cards</li>
+
+<li><strong>URI:</strong> 0313f9449cdb528dc9707c02da507cc9306eedc415091c07dc75dcdf621844a5ab@69.15.179.58:9735</li></ul></li>
+
 <p></p></li>
 </ul></p>
 

--- a/index.md
+++ b/index.md
@@ -12,6 +12,10 @@
     *   Buy and sell articles with other members
     *   **URI:** 02669e1e43577c14a4ae796a38e0cfdadb548615058e367bd96bf825e62c0932ce@34.200.241.1:9735
 
+*   [SoGBazaar](https://sogbazaar.com/)
+    *   Posters and digital cards
+    *   **URI:** 0313f9449cdb528dc9707c02da507cc9306eedc415091c07dc75dcdf621844a5ab@69.15.179.58:9735
+
 ### Coming soon
 
 *   [Bitrefill](https://en.bitrefill.com/)

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@
     *   Buy and sell articles with other members
     *   **URI:** 02669e1e43577c14a4ae796a38e0cfdadb548615058e367bd96bf825e62c0932ce@34.200.241.1:9735
 
-### Comming soon
+### Coming soon
 
 *   [Bitrefill](https://en.bitrefill.com/)
     *   Charge any cellphone with bitcoin


### PR DESCRIPTION
Adding SoGBazaar to the list of sites that accept payment via lightning. Lightning payments are enabled currently for all for orders up to 0.042 BTC but plan to accept it for all orders as things mature.

This pull also fixes a minor typo.