### PR TITLE
Add disable route watcher

### DIFF
--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -8,6 +8,7 @@
       :absolute="true"
       :inset="$vuetify.breakpoint.lgAndUp"
       width="300"
+      disable-route-watcher
     >
       <v-list>
         <v-subheader class="title pb-2">Sort</v-subheader>


### PR DESCRIPTION
As per Vuetify docs (https://vuetifyjs.com/en/api/v-navigation-drawer/#props-disable-route-watcher)

The default behaviour for the drawer has a watcher that closes it when the route changes, since sorting updates the route then it's better to disable the watcher and manage route changes manually later on if needed
