### PR TITLE
fix: adjusts url regex so that tag queries are detected

### DIFF
--- a/nuxt/plugins/filters.js
+++ b/nuxt/plugins/filters.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-const URL_REGEX = /([\w+]+\:\/\/)?([\w\d-]+\.)*[\w-]+[\.\:]\w+([\/\?\=\&\#\.]?[\w-]+)*\/?/g
+const URL_REGEX = /([\w+]+\:\/\/)?([\w\d-]+\.)*[\w-]+[\.\:]\w+([\/\?\=\&\#\.]?[\w-]+)*\/*\?*(\w|=|%20|\+)*/g
 const PROTOCOL_REGEX = /(http:\/\/|https:\/\/)/
 const TAGGED_REGEX = /@\w*/g
 


### PR DESCRIPTION
Adjusts the url regex so that both of these are detected:

- https://lightningnetworkstores.com?stacking%20sats
- https://lightningnetworkstores.com?stacking+sats